### PR TITLE
bugfix: Version 1.2 for liberty-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
                 <plugin>
                     <groupId>net.wasdev.wlp.maven.plugins</groupId>
                     <artifactId>liberty-maven-plugin</artifactId>
-                    <version>1.1</version>
+                    <version>1.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
With Version 1.1 this command:
$ mvn liberty:run-server
gets an error.

see: liberty-maven-plugin
